### PR TITLE
Improve input on Pythonista

### DIFF
--- a/linecount.py
+++ b/linecount.py
@@ -12,10 +12,11 @@ else:
     pythonista = False
 import requests
 
-USER = input("GitHub Username: ")
 if pythonista:
-    PASS = console.secure_input("GitHub Password: ")
+    USER = console.input_alert("GitHub Username: ")
+    PASS = console.password_alert("GitHub Password: ")
 else:
+    USER = input("GitHub Username: ")
     PASS = getpass.getpass("GitHub Password: ")
 
 

--- a/linecount.py
+++ b/linecount.py
@@ -3,11 +3,20 @@
 import getpass
 import json
 import os
+import sys
 
+if sys.platform == 'ios':
+    pythonista = True
+    import console
+else:
+    pythonista = False
 import requests
 
 USER = input("GitHub Username: ")
-PASS = getpass.getpass("GitHub Password: ")
+if pythonista:
+    PASS = console.secure_input("GitHub Password: ")
+else:
+    PASS = getpass.getpass("GitHub Password: ")
 
 
 def get(path, params={}):


### PR DESCRIPTION
If Pythonista is being used, the input will use `console.password_alert` for a slightly better experience.
