### PR TITLE
Add setup.py for script installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # vanity
 Count the number of additions you've made on GitHub in the last year
+You can use the script as it is or install it with `python setup.py install` which will put the script `vanity` into your path.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,60 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='vanity',
+    version='0.1.0',
+
+    description='Shows amount of lines contributed on GitHub in past year',
+    url='https://github.com/controversial/vanity',
+    author='Luke Taylor',
+    license='MIT',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 3 - Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Version Control',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+
+    # What does your project relate to?
+    keywords='git github',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    #packages=find_packages(),
+
+    # Alternatively, if you want to distribute just a my_module.py, uncomment
+    # this:
+    py_modules=["vanity"],
+
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=['requests'],
+
+    # To provide executable scripts, use entry points in preference to the
+    # "scripts" keyword. Entry points provide cross-platform support and allow
+    # pip to create the appropriate form of executable for the target platform.
+    entry_points={
+        'console_scripts': [
+            'vanity=vanity:main',
+        ],
+    },
+)

--- a/vanity.py
+++ b/vanity.py
@@ -137,7 +137,7 @@ def auth(username=None, password=None):
         print("- Success!")
 
 
-if __name__ == "__main__":
+def main():
     print(__doc__)
     argparser = argparse.ArgumentParser()
     argparser.add_argument("-u", "--username", help="Account username")
@@ -178,3 +178,7 @@ if __name__ == "__main__":
             sorted(gist_adds.items(), key=lambda x: x[1], reverse=True)
         )
     ][:10]))
+    
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
I wanted to learn how to use `setuptools` so I made a `setup.py` to install `vanity.py` as `vanity` into the path. I don't care if you don't actually accept this request; I just needed to learn `setuptools`.
